### PR TITLE
Fix code scanning alert no. 12: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -441,8 +441,8 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
     for (int rep = 0; rep < 50; ++rep) {
         AutoFile file{fsbridge::fopen(streams_test_filename, "w+b")};
         size_t fileSize = InsecureRandRange(256);
-        for (uint8_t i = 0; i < fileSize; ++i) {
-            file << i;
+        for (size_t i = 0; i < fileSize; ++i) {
+            file << static_cast<uint8_t>(i);
         }
         std::rewind(file.Get());
 


### PR DESCRIPTION
Fixes [https://github.com/Wbaker7702/bitcoin/security/code-scanning/12](https://github.com/Wbaker7702/bitcoin/security/code-scanning/12)

To fix the problem, we need to ensure that the type of `i` is at least as wide as the type of `fileSize`. Since `fileSize` is of type `size_t`, we should change the type of `i` to `size_t` as well. This will ensure that the comparison is between variables of the same type, preventing any potential issues related to type width.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
