### PR TITLE
Fix code scanning alert no. 11: Multiplication result converted to larger type

### DIFF
--- a/src/crypto/muhash.cpp
+++ b/src/crypto/muhash.cpp
@@ -46,7 +46,7 @@ inline void mulnadd3(limb_t& c0, limb_t& c1, limb_t& c2, limb_t& d0, limb_t& d1,
     t += (double_limb_t)d1 * n + c1;
     c1 = t;
     t >>= LIMB_SIZE;
-    c2 = t + d2 * n;
+    c2 = t + (double_limb_t)d2 * n;
 }
 
 /* [c0,c1] *= n */


### PR DESCRIPTION
Fixes [https://github.com/Wbaker7702/bitcoin/security/code-scanning/11](https://github.com/Wbaker7702/bitcoin/security/code-scanning/11)

To fix the problem, we need to ensure that the multiplication is performed using the larger integer type (`double_limb_t`) to avoid overflow. This can be achieved by casting one of the operands to `double_limb_t` before performing the multiplication. This way, the multiplication will be done in the larger type, preventing overflow.

Specifically, we need to modify the multiplication `d2 * n` on line 49 to cast one of the operands to `double_limb_t` before the multiplication.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
