### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 name: CI
+permissions:
+  contents: read
 on:
   # See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request.
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/bitcoin/security/code-scanning/13](https://github.com/Wbaker7702/bitcoin/security/code-scanning/13)

To address this problem, explicitly set a `permissions` block at the top level of the workflow file. This will ensure that all jobs in the workflow, unless they specifically override the block, run with the minimal privileges necessary—`contents: read` is usually the least-privilege setting for CI/testing workflows. This can be done by inserting a `permissions:` section right after the workflow `name: CI` line and before `on:` so that it applies to all jobs. No additional methods, imports, or package changes are needed. Only a YAML snippet insertion at the top of `.github/workflows/ci.yml` is needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration.

**Note:** This release contains no user-facing changes. Updates are limited to internal development infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->